### PR TITLE
Fix CORS issues with backend

### DIFF
--- a/Downloads/partilio/frontend/.env.example
+++ b/Downloads/partilio/frontend/.env.example
@@ -1,6 +1,6 @@
 # API Configuration
 NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
-NEXT_PUBLIC_API_BASE_URL=https://partilio-backend.onrender.com/api
+NEXT_PUBLIC_API_BASE_URL=/api
 
 # Environment
 NODE_ENV=production

--- a/Downloads/partilio/frontend/next.config.js
+++ b/Downloads/partilio/frontend/next.config.js
@@ -8,41 +8,34 @@ const nextConfig = {
   images: {
     domains: ['partilio-backend.onrender.com'],
   },
-  // Disable TypeScript checking during build (opcional)
   typescript: {
     ignoreBuildErrors: true,
   },
   eslint: {
     ignoreDuringBuilds: true,
   },
-  
-  // IMPORTANTE: Remover 'output: export' para permitir SSR
-  // Comentado: output: 'export',
-  // Comentado: trailingSlash: true,
-  
-  // Permitir funcionalidades do Next.js
   experimental: {
     appDir: true,
   },
-  
-  // Configuração para Render.com
   async headers() {
     return [
       {
         source: '/(.*)',
         headers: [
-          {
-            key: 'X-Frame-Options',
-            value: 'DENY',
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
         ],
       },
     ];
   },
-}
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'https://partilio-backend.onrender.com/api/:path*',
+      },
+    ];
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/Downloads/partilio/frontend/src/lib/api.ts
+++ b/Downloads/partilio/frontend/src/lib/api.ts
@@ -34,7 +34,7 @@ const removeFromStorage = (key: string): void => {
 };
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001/api',
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || '/api',
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- proxy API calls through Next.js rewrites
- use local `/api` base URL for axios

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run type-check` *(fails: multiple TypeScript errors)*


------
https://chatgpt.com/codex/tasks/task_e_6864c76239d483279c76add620f46c34