### PR TITLE
Update API env defaults

### DIFF
--- a/Downloads/partilio/frontend/.env.example
+++ b/Downloads/partilio/frontend/.env.example
@@ -1,6 +1,5 @@
 # API Configuration
-NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
-# Use the local "/api" proxy so Next.js can rewrite to the backend
+# NEXT_PUBLIC_API_URL is deprecated; use the local "/api" proxy so Next.js can rewrite to the backend
 NEXT_PUBLIC_API_BASE_URL=/api
 
 # Environment

--- a/Downloads/partilio/frontend/create_frontend.sh
+++ b/Downloads/partilio/frontend/create_frontend.sh
@@ -123,9 +123,7 @@ EOF
 cat > next.config.js << 'EOF'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-  },
+  // The API is accessed via the "/api" proxy defined in `rewrites`
   compress: true,
   poweredByHeader: false,
   images: {
@@ -217,8 +215,8 @@ EOF
 # .env.local
 cat > .env.local << 'EOF'
 # API Configuration
-NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
-NEXT_PUBLIC_API_BASE_URL=https://partilio-backend.onrender.com/api
+# NEXT_PUBLIC_API_URL is deprecated; use the local "/api" proxy instead
+NEXT_PUBLIC_API_BASE_URL=/api
 
 # Environment
 NODE_ENV=development
@@ -230,8 +228,8 @@ EOF
 # .env.example
 cat > .env.example << 'EOF'
 # API Configuration
-NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
-NEXT_PUBLIC_API_BASE_URL=https://partilio-backend.onrender.com/api
+# NEXT_PUBLIC_API_URL is deprecated; use the local "/api" proxy instead
+NEXT_PUBLIC_API_BASE_URL=/api
 
 # Environment
 NODE_ENV=production

--- a/Downloads/partilio/frontend/next.config.js
+++ b/Downloads/partilio/frontend/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-  },
+  // The API is accessed via the "/api" proxy defined in `rewrites`
   compress: true,
   poweredByHeader: false,
   images: {


### PR DESCRIPTION
## Summary
- simplify API environment setup
- drop deprecated `NEXT_PUBLIC_API_URL`
- create `.env.example` with `/api` base URL
- remove unused env variable in `next.config.js`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6864d72225d48327817a28424c4bb6ef