### PR TITLE
Use env var for rewrite

### DIFF
--- a/Downloads/partilio/frontend/.env.example
+++ b/Downloads/partilio/frontend/.env.example
@@ -1,6 +1,7 @@
 # API Configuration
+# Base backend host used by the Next.js rewrite rule
 NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
-# Use the local "/api" proxy so Next.js can rewrite to the backend
+# Use the local "/api" proxy so Next.js can rewrite to `${NEXT_PUBLIC_API_URL}`
 NEXT_PUBLIC_API_BASE_URL=/api
 
 # Environment

--- a/Downloads/partilio/frontend/next.config.js
+++ b/Downloads/partilio/frontend/next.config.js
@@ -32,7 +32,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: 'https://partilio-backend.onrender.com/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- load the backend host from `NEXT_PUBLIC_API_URL` when rewriting API calls
- document the new behaviour in `.env.example`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Property 'token' does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864d7310db08327a093108bda62cd16