### PR TITLE
Remove unused NEXT_PUBLIC_API_URL

### DIFF
--- a/Downloads/partilio/frontend/.env.example
+++ b/Downloads/partilio/frontend/.env.example
@@ -1,5 +1,4 @@
 # API Configuration
-NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
 # Use the local "/api" proxy so Next.js can rewrite to the backend
 NEXT_PUBLIC_API_BASE_URL=/api
 

--- a/Downloads/partilio/frontend/README.md
+++ b/Downloads/partilio/frontend/README.md
@@ -28,6 +28,14 @@ npm run build
 npm start
 ```
 
+## 🔑 Variáveis de Ambiente
+
+Crie um arquivo `.env.local` com base em `.env.example` para configurar a aplicação.
+
+- `NEXT_PUBLIC_API_BASE_URL` - Base das requisições para a API (padrão `/api`)
+- `NODE_ENV` - Define o ambiente (por padrão `production`)
+- `NEXT_PUBLIC_ENABLE_DEVTOOLS` - Ativa o React Query Devtools no cliente
+
 ## 🌐 URLs
 
 - **Local:** http://localhost:3000

--- a/Downloads/partilio/frontend/create_frontend.sh
+++ b/Downloads/partilio/frontend/create_frontend.sh
@@ -123,9 +123,6 @@ EOF
 cat > next.config.js << 'EOF'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-  },
   compress: true,
   poweredByHeader: false,
   images: {
@@ -217,7 +214,6 @@ EOF
 # .env.local
 cat > .env.local << 'EOF'
 # API Configuration
-NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
 NEXT_PUBLIC_API_BASE_URL=https://partilio-backend.onrender.com/api
 
 # Environment
@@ -230,7 +226,6 @@ EOF
 # .env.example
 cat > .env.example << 'EOF'
 # API Configuration
-NEXT_PUBLIC_API_URL=https://partilio-backend.onrender.com
 NEXT_PUBLIC_API_BASE_URL=https://partilio-backend.onrender.com/api
 
 # Environment

--- a/Downloads/partilio/frontend/next.config.js
+++ b/Downloads/partilio/frontend/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-  },
   compress: true,
   poweredByHeader: false,
   images: {


### PR DESCRIPTION
## Summary
- remove `NEXT_PUBLIC_API_URL` variable
- document current env vars

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Property 'token' does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864d73d152483278969d145cb6bc5bc