### PR TITLE
Add ESLint check for backend URL

### DIFF
--- a/Downloads/partilio/frontend/.eslintrc.json
+++ b/Downloads/partilio/frontend/.eslintrc.json
@@ -1,3 +1,12 @@
 {
-  "extends": "next"
+  "extends": "next",
+  "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "Literal[value='https://partilio-backend.onrender.com']",
+        "message": "Hardcoded backend URL is not allowed; use environment variables instead."
+      }
+    ]
+  }
 }

--- a/Downloads/partilio/frontend/README.md
+++ b/Downloads/partilio/frontend/README.md
@@ -86,3 +86,7 @@ app.options('*', cors());
 ```
 
 A configuração também pode ser adaptada para **NestJS** ou **Fastify** seguindo a mesma ideia. Certifique-se de definir a variável `CORS_ORIGIN` na Render para incluir a URL do frontend e `http://localhost:3000` quando for necessário.
+
+## ✔️ Qualidade de Código
+
+Execute `npm run lint` para verificar problemas de estilo e garantir que nenhuma parte do código contenha a URL fixa `https://partilio-backend.onrender.com`. O comando falhará se encontrar essa string.


### PR DESCRIPTION
## Summary
- add ESLint rule to detect usage of https://partilio-backend.onrender.com
- document the lint command in README for contributors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864d745e5588327b2802ec6d5ca2b25